### PR TITLE
Clarify PSK can't be used with certificate-based auth unless there is…

### DIFF
--- a/draft-rescorla-tls-rfc8446-bis.md
+++ b/draft-rescorla-tls-rfc8446-bis.md
@@ -5456,7 +5456,7 @@ the server's certificate (see also {{Kraw16}}). It is unsafe to use certificate-
 authentication when the client might potentially share the same
 PSK/key-id pair with two different endpoints.  Implementations MUST
 NOT combine external PSKs with certificate-based authentication of
-either client or the server. Future specifications MAY provide an
+either the client or server. Future specifications MAY provide an
 extension to permit this.
 
 If an exporter is used, then it produces values which are unique

--- a/draft-rescorla-tls-rfc8446-bis.md
+++ b/draft-rescorla-tls-rfc8446-bis.md
@@ -5454,9 +5454,10 @@ the PSK binder. {{PSK-FINISHED}}
 describes a concrete attack on constructions that do not bind to
 the server's certificate (see also {{Kraw16}}). It is unsafe to use certificate-based client
 authentication when the client might potentially share the same
-PSK/key-id pair with two different endpoints.  Implementations MUST NOT combine
-external PSKs with certificate-based authentication of either the
-client or the server unless negotiated by some extension.
+PSK/key-id pair with two different endpoints.  Implementations MUST
+NOT combine external PSKs with certificate-based authentication of
+either client or the server. Future specifications MAY provide an
+extension to permit this.
 
 If an exporter is used, then it produces values which are unique
 and secret (because they are generated from a unique session key).


### PR DESCRIPTION
… some future extension. Fixes #52, Fixes #51