### PR TITLE
Remove redundant PSK text. Fixes erratum 6138.

### DIFF
--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -657,7 +657,7 @@ draft-27
 - SHOULD->MUST for being able to process "supported_versions" without
   0x0304.
 
-- Much editorial cleanup.
+- Much editorial cleanup. 
 
 draft-26
 
@@ -3068,7 +3068,10 @@ PSK:
 - The selected ALPN {{RFC7301}} protocol, if any
 
 These requirements are a superset of those needed to perform a 1-RTT
-handshake using the PSK in question.
+handshake using the PSK in question.  For externally established PSKs, the
+associated values are those provisioned along with the key.  For PSKs
+established via a NewSessionTicket message, the associated values are those
+negotiated in the connection during which the ticket was established.
 
 Future extensions MUST define their interaction with 0-RTT.
 

--- a/draft-ietf-tls-tls13.md
+++ b/draft-ietf-tls-tls13.md
@@ -657,7 +657,7 @@ draft-27
 - SHOULD->MUST for being able to process "supported_versions" without
   0x0304.
 
-- Much editorial cleanup. 
+- Much editorial cleanup.
 
 draft-26
 
@@ -3068,10 +3068,7 @@ PSK:
 - The selected ALPN {{RFC7301}} protocol, if any
 
 These requirements are a superset of those needed to perform a 1-RTT
-handshake using the PSK in question.  For externally established PSKs, the
-associated values are those provisioned along with the key.  For PSKs
-established via a NewSessionTicket message, the associated values are those
-negotiated in the connection during which the ticket was established.
+handshake using the PSK in question.
 
 Future extensions MUST define their interaction with 0-RTT.
 

--- a/draft-rescorla-tls-rfc8446-bis.md
+++ b/draft-rescorla-tls-rfc8446-bis.md
@@ -2451,10 +2451,7 @@ PSK:
 - The selected ALPN {{!RFC7301}} protocol, if any
 
 These requirements are a superset of those needed to perform a 1-RTT
-handshake using the PSK in question.  For externally established PSKs, the
-associated values are those provisioned along with the key.  For PSKs
-established via a NewSessionTicket message, the associated values are those
-negotiated in the connection during which the ticket was established.
+handshake using the PSK in question.
 
 Future extensions MUST define their interaction with 0-RTT.
 


### PR DESCRIPTION
I also rant the linter to remove an extra whitespace.

Closes #45.